### PR TITLE
Fix `lerna run test` hanging issue

### DIFF
--- a/packages/react-playground/package.json
+++ b/packages/react-playground/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "CI=true react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   }
 }


### PR DESCRIPTION
The react-playground package has a cute test runner meant for development—not great for CLI. Rather than running and exiting, it watches and stays open waiting for file changes.

Passing `CI=true` to the test runner causes it to run all files and exit.