### PR TITLE
Fix keyboard events in Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "nyc": "^10.1.2",
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.4.1",
+    "raf-stub": "^2.0.0",
     "react-dom": "^15.4.1",
+    "sinon-chai": "^2.8.0",
     "web-component-tester": "4.2.2",
     "web-component-tester-istanbul": "^0.10.0"
   }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,6 +23,9 @@
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
-    "eslint-plugin-react": "^6.8.0"
+    "eslint-plugin-react": "^6.8.0",
+    "raf-stub": "^2.0.0",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/packages/components/src/2016-12-01/button.js
+++ b/packages/components/src/2016-12-01/button.js
@@ -176,7 +176,7 @@ class Button extends Element {
     }));
   }
 
-  _render() {
+  render() {
     if (this.state.disabled) {
       this.viewState.background = 'grey';
       this.viewState.color = 'white';
@@ -203,7 +203,7 @@ class Button extends Element {
         break;
     }
 
-    super._render();
+    super.render();
   }
 }
 

--- a/packages/components/src/2016-12-01/element.js
+++ b/packages/components/src/2016-12-01/element.js
@@ -45,7 +45,7 @@ class Element extends HTMLElement {
     (new RenderQueue()).add(this);
   }
 
-  _render() {
+  render() {
     this._updateClassName();
   }
 

--- a/packages/components/src/2016-12-01/element.js
+++ b/packages/components/src/2016-12-01/element.js
@@ -17,6 +17,7 @@ limitations under the License.
 require('../../vendor/es5-custom-element-shim.js');
 require('../../vendor/object-entries-shim.js');
 require('../utils/inject-styles.js');
+const RenderQueue = require('../utils/render-queue.js');
 const Registry = require('../utils/private-registry.js');
 const { BorderRadius, BoxShadow, Container, Display, Hovers, Position, ResetFocusStyle, Skins, Spacing } = require('@orion-ui/style/lib/2016-12-01');
 
@@ -37,18 +38,11 @@ class Element extends HTMLElement {
     super();
     this.state = {};
     this.viewState = {};
+    this._queueRender();
   }
 
   _queueRender() {
-    if (this._renderQueued) {
-      return;
-    }
-
-    this._renderQueued = true;
-    requestAnimationFrame(() => {
-      this._renderQueued = false;
-      this._render();
-    });
+    (new RenderQueue()).add(this);
   }
 
   _render() {

--- a/packages/components/src/2016-12-01/list.js
+++ b/packages/components/src/2016-12-01/list.js
@@ -49,7 +49,7 @@ class List extends Element {
     return this.state.itemTagname;
   }
 
-  _render() {
+  render() {
     // TODO: raise warning if no key
     // TODO: raise warning if duplicate key
 
@@ -68,7 +68,7 @@ class List extends Element {
     });
 
     this.lastItemsHash = hashFromItems(this.items);
-    super._render();
+    super.render();
   }
 }
 

--- a/packages/components/src/2016-12-01/select-menu.js
+++ b/packages/components/src/2016-12-01/select-menu.js
@@ -96,7 +96,7 @@ class SelectMenu extends Element {
     this.dispatchEvent(new CustomEvent('closed'));
   }
 
-  _render() {
+  render() {
     this._ensureList();
 
     if (this.state.open) {
@@ -121,7 +121,7 @@ class SelectMenu extends Element {
       this._removeList();
     }
 
-    super._render();
+    super.render();
   }
 }
 

--- a/packages/components/src/2016-12-01/select-option.js
+++ b/packages/components/src/2016-12-01/select-option.js
@@ -111,7 +111,7 @@ class SelectOption extends Element {
     this.addEventListener('mouseenter', this._handleMouseEnter);
   }
 
-  _render() {
+  render() {
     if (this.button !== undefined) {
       let styles;
       if (this.state.hasFocus) {
@@ -130,7 +130,7 @@ class SelectOption extends Element {
       this.labelEl.textContent = this.state.label;
     }
 
-    super._render();
+    super.render();
   }
 }
 

--- a/packages/components/src/2016-12-01/select.js
+++ b/packages/components/src/2016-12-01/select.js
@@ -192,7 +192,7 @@ class Select extends Element {
     }));
   }
 
-  _render() {
+  render() {
     this._ensureButton();
     this._ensureMenu();
 
@@ -215,7 +215,7 @@ class Select extends Element {
       hasFocus: (this.state.hasFocus && !this.state.open),
     });
 
-    super._render();
+    super.render();
   }
 }
 

--- a/packages/components/src/utils/event-key.js
+++ b/packages/components/src/utils/event-key.js
@@ -25,6 +25,5 @@ const keyStrings = {
 };
 
 module.exports = function eventKey(event) {
-  if (event.key !== undefined) { return event.key; }
   return keyStrings[event.keyCode];
 };

--- a/packages/components/src/utils/event-key.js
+++ b/packages/components/src/utils/event-key.js
@@ -14,16 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-const keyStrings = {
-  9: 'Tab',
-  13: 'Enter',
-  27: 'Escape',
-  37: 'ArrowLeft',
-  38: 'ArrowUp',
-  39: 'ArrowRight',
-  40: 'ArrowDown',
-};
+const valueSets = [
+  { key: 'Tab', values: [9, 'Tab'] },
+  { key: 'Enter', values: [13, 'Enter'] },
+  { key: 'Escape', values: [27, 'Escape'] },
+  { key: 'ArrowLeft', values: [37, 'ArrowLeft', 'Left'] },
+  { key: 'ArrowUp', values: [38, 'ArrowUp', 'Up'] },
+  { key: 'ArrowRight', values: [39, 'ArrowRight', 'Right'] },
+  { key: 'ArrowDown', values: [40, 'ArrowDown', 'Down'] },
+];
+
+function match(valueSet, keyCode, key) {
+  return valueSet.values.includes(keyCode) || valueSet.values.includes(key);
+}
 
 module.exports = function eventKey(event) {
-  return keyStrings[event.keyCode];
+  const matchingSet = valueSets.find((valueSet) => {
+    return match(valueSet, event.key, event.keyCode);
+  });
+
+  if (matchingSet === undefined) { return null; }
+  return matchingSet.key;
 };

--- a/packages/components/src/utils/event-key.test.js
+++ b/packages/components/src/utils/event-key.test.js
@@ -1,0 +1,64 @@
+/**
+Copyright 2016 Autodesk,Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+const eventKey = require('./event-key');
+const chai = require('chai');
+
+const expect = chai.expect;
+
+describe('Utils.eventKey', () => {
+  let event;
+
+  context('with a keyCode', () => {
+    beforeEach(() => {
+      event = { keyCode: 37 };
+    });
+
+    it('returns the standards-compliant key', () => {
+      expect(eventKey(event)).to.eq('ArrowLeft');
+    });
+  });
+
+  context('with a standards-compliant key', () => {
+    beforeEach(() => {
+      event = { key: 'ArrowLeft' };
+    });
+
+    it('returns the standards-compliant key', () => {
+      expect(eventKey(event)).to.eq('ArrowLeft');
+    });
+  });
+
+  context('with a key from Edge', () => {
+    beforeEach(() => {
+      event = { key: 'Left' };
+    });
+
+    it('returns the standards-compliant key', () => {
+      expect(eventKey(event)).to.eq('ArrowLeft');
+    });
+  });
+
+  context('with an unsupported key', () => {
+    beforeEach(() => {
+      event = { keyCode: 100 };
+    });
+
+    it('returns null', () => {
+      expect(eventKey(event)).to.be.null; // eslint-disable-line no-unused-expressions
+    });
+  });
+});

--- a/packages/components/src/utils/render-queue.js
+++ b/packages/components/src/utils/render-queue.js
@@ -30,19 +30,19 @@ class RenderQueue {
 
   add(element) {
     this.queue.add(element);
-    if (this._renderQueued) { return; }
+    if (this.renderQueued) { return; }
 
-    this._renderQueued = true;
+    this.renderQueued = true;
     requestAnimationFrame(this.flush);
   }
 
   flush() {
     const elements = new Set(this.queue);
     this.queue.clear();
-    this._renderQueued = false;
+    this.renderQueued = false;
 
     elements.forEach((element) => {
-      element._render(); // eslint-disable-line no-underscore-dangle
+      element.render(); // eslint-disable-line no-underscore-dangle
     });
   }
 }

--- a/packages/components/src/utils/render-queue.js
+++ b/packages/components/src/utils/render-queue.js
@@ -1,0 +1,50 @@
+/**
+Copyright 2016 Autodesk,Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+let instance = null;
+
+class RenderQueue {
+  constructor() {
+    if (!instance) {
+      instance = this;
+    }
+
+    this.queue = new Set();
+    this.flush = this.flush.bind(this);
+
+    return instance;
+  }
+
+  add(element) {
+    this.queue.add(element);
+    if (this._renderQueued) { return; }
+
+    this._renderQueued = true;
+    requestAnimationFrame(this.flush);
+  }
+
+  flush() {
+    const elements = new Set(this.queue);
+    this.queue.clear();
+    this._renderQueued = false;
+
+    elements.forEach((element) => {
+      element._render(); // eslint-disable-line no-underscore-dangle
+    });
+  }
+}
+
+module.exports = RenderQueue;

--- a/packages/components/src/utils/render-queue.test.js
+++ b/packages/components/src/utils/render-queue.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /**
 Copyright 2016 Autodesk,Inc.
 
@@ -43,7 +44,7 @@ describe('Utils.RenderQueue', () => {
       let element;
 
       beforeEach(() => {
-        element = { _render: sinon.spy() };
+        element = { render: sinon.spy() };
         renderQueue.add(element);
         renderQueue.add(element);
         renderQueue.add(element);
@@ -55,7 +56,7 @@ describe('Utils.RenderQueue', () => {
         });
 
         it('calls the callback once', () => {
-          expect(element._render).to.have.been.calledOnce;
+          expect(element.render).to.have.been.calledOnce;
         });
       });
 
@@ -65,10 +66,9 @@ describe('Utils.RenderQueue', () => {
         });
 
         it('is called only once', () => {
-          expect(element._render).to.have.been.calledOnce;
+          expect(element.render).to.have.been.calledOnce;
         });
       });
-
     });
 
     context('when a render triggers another render', () => {
@@ -79,8 +79,8 @@ describe('Utils.RenderQueue', () => {
       beforeEach(() => {
         childRender = sinon.spy();
 
-        childElement = { _render: childRender };
-        parentElement = { _render: () => { renderQueue.add(childElement); } };
+        childElement = { render: childRender };
+        parentElement = { render: () => { renderQueue.add(childElement); } };
 
         renderQueue.add(parentElement);
       });
@@ -94,9 +94,9 @@ describe('Utils.RenderQueue', () => {
     });
 
     context('with 3 different elements', () => {
-      const element1 = { _render: sinon.spy() };
-      const element2 = { _render: sinon.spy() };
-      const element3 = { _render: sinon.spy() };
+      const element1 = { render: sinon.spy() };
+      const element2 = { render: sinon.spy() };
+      const element3 = { render: sinon.spy() };
 
       beforeEach(() => {
         renderQueue.add(element1);
@@ -106,15 +106,15 @@ describe('Utils.RenderQueue', () => {
       });
 
       it('renders each of them once', () => {
-        expect(element1._render).to.have.been.calledOnce;
-        expect(element2._render).to.have.been.calledOnce;
-        expect(element3._render).to.have.been.calledOnce;
+        expect(element1.render).to.have.been.calledOnce;
+        expect(element2.render).to.have.been.calledOnce;
+        expect(element3.render).to.have.been.calledOnce;
       });
     });
   });
 
   describe('#flush', () => {
-    const element = { _render: sinon.spy() };
+    const element = { render: sinon.spy() };
 
     beforeEach(() => {
       renderQueue.add(element);
@@ -122,7 +122,7 @@ describe('Utils.RenderQueue', () => {
 
     it('calls all queued callbacks synchronously', () => {
       renderQueue.flush();
-      expect(element._render).to.have.been.calledOnce; // eslint-disable-line no-unused-expressions
+      expect(element.render).to.have.been.calledOnce;
     });
   });
 });

--- a/packages/components/src/utils/render-queue.test.js
+++ b/packages/components/src/utils/render-queue.test.js
@@ -1,0 +1,128 @@
+/**
+Copyright 2016 Autodesk,Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+const replaceRaf = require('raf-stub').replaceRaf;
+
+replaceRaf();
+
+const RenderQueue = require('./render-queue');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+const expect = chai.expect;
+
+describe('Utils.RenderQueue', () => {
+  let renderQueue;
+
+  beforeEach(() => {
+    renderQueue = new RenderQueue();
+  });
+
+  afterEach(() => {
+    renderQueue.flush();
+  });
+
+  describe('#add', () => {
+    context('called 3 times', () => {
+      let element;
+
+      beforeEach(() => {
+        element = { _render: sinon.spy() };
+        renderQueue.add(element);
+        renderQueue.add(element);
+        renderQueue.add(element);
+      });
+
+      context('after the next animation frame', () => {
+        beforeEach(() => {
+          requestAnimationFrame.step();
+        });
+
+        it('calls the callback once', () => {
+          expect(element._render).to.have.been.calledOnce;
+        });
+      });
+
+      context('after two frames', () => {
+        beforeEach(() => {
+          requestAnimationFrame.step(2);
+        });
+
+        it('is called only once', () => {
+          expect(element._render).to.have.been.calledOnce;
+        });
+      });
+
+    });
+
+    context('when a render triggers another render', () => {
+      let parentElement;
+      let childElement;
+      let childRender;
+
+      beforeEach(() => {
+        childRender = sinon.spy();
+
+        childElement = { _render: childRender };
+        parentElement = { _render: () => { renderQueue.add(childElement); } };
+
+        renderQueue.add(parentElement);
+      });
+
+      it('gets called on the next frame', () => {
+        requestAnimationFrame.step();
+        expect(childRender).not.to.have.been.called;
+        requestAnimationFrame.step();
+        expect(childRender).to.have.been.calledOnce;
+      });
+    });
+
+    context('with 3 different elements', () => {
+      const element1 = { _render: sinon.spy() };
+      const element2 = { _render: sinon.spy() };
+      const element3 = { _render: sinon.spy() };
+
+      beforeEach(() => {
+        renderQueue.add(element1);
+        renderQueue.add(element2);
+        renderQueue.add(element3);
+        requestAnimationFrame.step();
+      });
+
+      it('renders each of them once', () => {
+        expect(element1._render).to.have.been.calledOnce;
+        expect(element2._render).to.have.been.calledOnce;
+        expect(element3._render).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  describe('#flush', () => {
+    const element = { _render: sinon.spy() };
+
+    beforeEach(() => {
+      renderQueue.add(element);
+    });
+
+    it('calls all queued callbacks synchronously', () => {
+      renderQueue.flush();
+      expect(element._render).to.have.been.calledOnce; // eslint-disable-line no-unused-expressions
+    });
+  });
+});

--- a/test/list.test.html
+++ b/test/list.test.html
@@ -43,7 +43,7 @@ limitations under the License.
         list = fixture('list');
         list.itemTagname = 'span';
         list.items = options;
-        list._render();
+        list.render();
       });
 
       it('renders each item', () => {
@@ -55,7 +55,7 @@ limitations under the License.
       context('adding an item', () => {
         beforeEach(() => {
           list.items = options.concat([{ textContent: 'Bax' }]);
-          list._render();
+          list.render();
         });
 
         it('adds the item to the dom', () => {
@@ -69,7 +69,7 @@ limitations under the License.
             item.textContent = item.textContent + 'bi';
             return item;
           });
-          list._render();
+          list.render();
         });
 
         it('updates item in the dom', () => {
@@ -87,7 +87,7 @@ limitations under the License.
             { textContent: 'Foo', key: 1 },
             { textContent: 'Bar', key: 2 },
           ]
-          list._render();
+          list.render();
         });
 
         it('renders items in new order', () => {
@@ -101,7 +101,7 @@ limitations under the License.
       context('removing an item', () => {
         beforeEach(() => {
           list.items = options.slice(1, 3);
-          list._render();
+          list.render();
         });
 
         it('removes the item from the dom', () => {

--- a/test/select.test.html
+++ b/test/select.test.html
@@ -42,8 +42,9 @@ limitations under the License.
     describe('<orion-select>', () => {
       var select, button, menu, wrapper;
 
+      beforeEach(() => wrapper = fixture('select'))
+
       beforeEach(() => {
-        wrapper = fixture('select');
         select = wrapper.querySelector('orion-select');
         button = select.querySelector('orion-button');
 
@@ -127,7 +128,7 @@ limitations under the License.
           var menu;
 
           beforeEach((done) => {
-            select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }));
             setTimeout(() => {
               menu = select.querySelector('orion-list');
               done();
@@ -144,8 +145,8 @@ limitations under the License.
 
             beforeEach((done) => {
               initialIndex = select.state.selectedIndex;
-              select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' })); // Focus next option
-              select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+              select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 })); // Focus next option
+              select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13 }));
               setTimeout(() => {
                 done();
               }, 75);

--- a/test/select.test.html
+++ b/test/select.test.html
@@ -58,14 +58,13 @@ limitations under the License.
       });
 
       context('after clicking', () => {
-        beforeEach((done) => {
+        beforeEach(() => {
           button.dispatchEvent(new Event('mouseenter'));
           button.dispatchEvent(new Event('mousedown'));
           button.dispatchEvent(new Event('mouseup'));
-          setTimeout(() => {
-            menu = select.querySelector('orion-list');
-            done();
-          }, 300);
+          (new RenderQueue()).flush();
+
+          menu = select.querySelector('orion-list');
         });
 
         it('shows a menu of options', () => {
@@ -80,44 +79,35 @@ limitations under the License.
             option.dispatchEvent(new Event('mouseenter'));
             option.dispatchEvent(new Event('mousedown'));
             option.dispatchEvent(new Event('mouseup'));
+            (new RenderQueue()).flush();
           });
 
-          it('closes the menu', (done) => {
-            setTimeout(() => {
-              expect(select.querySelector('orion-list')).to.be.null;
-              done();
-            }, 300);
+          it('closes the menu', () => {
+            expect(select.querySelector('orion-list')).to.be.null;
           });
 
-          it('shows the selected label', (done) => {
-            setTimeout(() => {
-              expect(select.innerText).to.have.string('Aardvarks');
-              done();
-            }, 300);
+          it('shows the selected label', () => {
+            expect(select.innerText).to.have.string('Aardvarks');
           });
         });
 
         context('and clicking away', () => {
           beforeEach(() => {
             button.dispatchEvent(new Event('blur'));
+            (new RenderQueue()).flush();
           });
 
-          it('closes the menu', (done) => {
-            setTimeout(() => {
-              let menu = select.querySelector('orion-list');
-              expect(menu).to.be.null;
-              done();
-            }, 300);
+          it('closes the menu', () => {
+            let menu = select.querySelector('orion-list');
+            expect(menu).to.be.null;
           });
         });
       });
 
       context('after focusing the button', () => {
-        beforeEach((done) => {
-          setTimeout(() => {
-            button.dispatchEvent(new Event('focus'));
-            done();
-          }, 300);
+        beforeEach(() => {
+          button.dispatchEvent(new Event('focus'));
+          (new RenderQueue()).flush();
         });
 
         it('has focus', () => {
@@ -127,12 +117,11 @@ limitations under the License.
         context('pressing an arrow key', () => {
           var menu;
 
-          beforeEach((done) => {
+          beforeEach(() => {
             select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 }));
-            setTimeout(() => {
-              menu = select.querySelector('orion-list');
-              done();
-            }, 300);
+            (new RenderQueue()).flush();
+
+            menu = select.querySelector('orion-list');
           });
 
           it('opens the menu', () => {
@@ -143,13 +132,11 @@ limitations under the License.
           context('then pressing enter', () => {
             var initialIndex;
 
-            beforeEach((done) => {
+            beforeEach(() => {
               initialIndex = select.state.selectedIndex;
               select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: 40 })); // Focus next option
               select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13 }));
-              setTimeout(() => {
-                done();
-              }, 300);
+              (new RenderQueue()).flush();
             });
 
             it('closes the menu', () => {
@@ -164,12 +151,10 @@ limitations under the License.
           context('then pressing escape', () => {
             var initialIndex;
 
-            beforeEach((done) => {
+            beforeEach(() => {
               initialIndex = select.state.selectedIndex;
               select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-              setTimeout(() => {
-                done();
-              }, 300);
+              (new RenderQueue()).flush();
             });
 
             it('closes the menu', () => {
@@ -183,11 +168,9 @@ limitations under the License.
         });
 
         context('blurring the button', () => {
-          beforeEach((done) => {
-            setTimeout(() => {
-              button.dispatchEvent(new Event('blur'));
-              done();
-            }, 300);
+          beforeEach(() => {
+            button.dispatchEvent(new Event('blur'));
+            (new RenderQueue()).flush();
           });
 
           it('no longer has focus', () => {

--- a/test/select.test.html
+++ b/test/select.test.html
@@ -65,7 +65,7 @@ limitations under the License.
           setTimeout(() => {
             menu = select.querySelector('orion-list');
             done();
-          }, 75);
+          }, 300);
         });
 
         it('shows a menu of options', () => {
@@ -86,14 +86,14 @@ limitations under the License.
             setTimeout(() => {
               expect(select.querySelector('orion-list')).to.be.null;
               done();
-            }, 75);
+            }, 300);
           });
 
           it('shows the selected label', (done) => {
             setTimeout(() => {
               expect(select.innerText).to.have.string('Aardvarks');
               done();
-            }, 75);
+            }, 300);
           });
         });
 
@@ -107,7 +107,7 @@ limitations under the License.
               let menu = select.querySelector('orion-list');
               expect(menu).to.be.null;
               done();
-            }, 75);
+            }, 300);
           });
         });
       });
@@ -117,7 +117,7 @@ limitations under the License.
           setTimeout(() => {
             button.dispatchEvent(new Event('focus'));
             done();
-          }, 75);
+          }, 300);
         });
 
         it('has focus', () => {
@@ -132,7 +132,7 @@ limitations under the License.
             setTimeout(() => {
               menu = select.querySelector('orion-list');
               done();
-            }, 75);
+            }, 300);
           });
 
           it('opens the menu', () => {
@@ -149,7 +149,7 @@ limitations under the License.
               select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13 }));
               setTimeout(() => {
                 done();
-              }, 75);
+              }, 300);
             });
 
             it('closes the menu', () => {
@@ -169,7 +169,7 @@ limitations under the License.
               select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
               setTimeout(() => {
                 done();
-              }, 75);
+              }, 300);
             });
 
             it('closes the menu', () => {
@@ -187,7 +187,7 @@ limitations under the License.
             setTimeout(() => {
               button.dispatchEvent(new Event('blur'));
               done();
-            }, 75);
+            }, 300);
           });
 
           it('no longer has focus', () => {


### PR DESCRIPTION
Edge uses a different string for the `keyCode` for arrow down then chrome. The `keyCode` was undefined in firefox so this was not an issue when we were trying to use `keyStrings`. Because edge uses different `keyStrings` than chrome, so we need to use keyCodes and are unable to use keyStrings. 