### PR TITLE
Add Orion Weather to marketing page

### DIFF
--- a/packages/marketing/src/App.js
+++ b/packages/marketing/src/App.js
@@ -110,7 +110,7 @@ class App extends Component {
               </tr>
               <tr>
                 <td className="pv3 pr3 bb b--black-20">Weather</td>
-                <td className="pv3 pr3 bb b--black-20">An app using Orion components and </td>
+                <td className="pv3 pr3 bb b--black-20">An app using Orion components and an external API</td>
                 <td className="pv3 pr3 bb b--black-20"><a href="https://orion-weather.glitch.me">view site</a></td>
                 <td className="pv3 pr3 bb b--black-20"><a href="https://glitch.com/edit/#!/orion-weather">view source</a></td>
               </tr>

--- a/packages/marketing/src/App.js
+++ b/packages/marketing/src/App.js
@@ -99,14 +99,20 @@ class App extends Component {
               <tr>
                 <td className="pv3 pr3 bb b--black-20">React Minimal</td>
                 <td className="pv3 pr3 bb b--black-20">Simple integration using <a href="https://github.com/facebookincubator/create-react-app">create-react-app</a></td>
-                <td className="pv3 pr3 bb b--black-20"><a href="https://orion-react-minimal.gomix.me">view site</a></td>
-                <td className="pv3 pr3 bb b--black-20"><a href="https://gomix.com/#!/project/orion-react-minimal">view source</a></td>
+                <td className="pv3 pr3 bb b--black-20"><a href="https://orion-react-minimal.glitch.me">view site</a></td>
+                <td className="pv3 pr3 bb b--black-20"><a href="https://glitch.com/edit/#!/orion-react-minimal">view source</a></td>
               </tr>
               <tr>
                 <td className="pv3 pr3 bb b--black-20">Angular Minimal</td>
                 <td className="pv3 pr3 bb b--black-20">Simple integration example</td>
-                <td className="pv3 pr3 bb b--black-20"><a href="https://orion-react-minimal.gomix.me">view site</a></td>
-                <td className="pv3 pr3 bb b--black-20"><a href="https://gomix.com/#!/project/orion-angular-minimal2">view source</a></td>
+                <td className="pv3 pr3 bb b--black-20"><a href="https://orion-angular-minimal2.glitch.me/">view site</a></td>
+                <td className="pv3 pr3 bb b--black-20"><a href="https://glitch.com/edit/#!/project/orion-angular-minimal2">view source</a></td>
+              </tr>
+              <tr>
+                <td className="pv3 pr3 bb b--black-20">Weather</td>
+                <td className="pv3 pr3 bb b--black-20">An app using Orion components and </td>
+                <td className="pv3 pr3 bb b--black-20"><a href="https://orion-weather.glitch.me">view site</a></td>
+                <td className="pv3 pr3 bb b--black-20"><a href="https://glitch.com/edit/#!/orion-weather">view source</a></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Also, correct view link to the minimal angular example, and update urls to use glitch.com rather than gomix.com.

Also, on Glitch, I've completed the other items on #80 —
- Renamed project to `orion-weather`
- Add @camwest as a collaborator.
- Moved the Dark Sky API Key into `.env` & added instructions for setting it there.

Also, a little bonus:
- When Dark Sky returns an error show a hint to set the API key.

Completes #80 